### PR TITLE
Update GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/check-badges.yml
+++ b/.github/workflows/check-badges.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Check badges in README.md
       run: ./scripts/check-badges.bash "README.md"

--- a/.github/workflows/python-latest.yml
+++ b/.github/workflows/python-latest.yml
@@ -40,9 +40,9 @@ jobs:
     continue-on-error: true
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python on ${{ matrix.operating-system }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip' # caching pip dependencies

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,9 +20,9 @@ jobs:
         python-version: [ '3.9', '3.12' ]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip' # caching pip dependencies

--- a/.github/workflows/twine-check.yml
+++ b/.github/workflows/twine-check.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
           python-version: '3.x'
           cache: 'pip' # caching pip dependencies


### PR DESCRIPTION
## Summary
- GitHub is deprecating Node 20 on Actions runners (EOL April 2026, removal Fall 2026)
- Updated all actions to their latest major versions with Node 24 runtime support
- actions/checkout v4 → v6
- actions/setup-python v4 → v6

## Test plan
- [ ] CI workflows pass on this PR branch