### PR TITLE
Enable PyPI trusted publishing

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.12'
+          python-version: '3.x'
           cache: 'pip'
 
       - name: Install publish requirements

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,33 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install publish requirements
+        run: python -m pip install -r publish-requirements.txt
+
+      - name: Build distributions
+        run: python setup.py sdist bdist_wheel --universal
+
+      - name: Check distributions
+        run: python -m twine check dist/* --strict
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for publishing to PyPI on tag push
- use OIDC-based trusted publishing instead of a long-lived PyPI token
- align the new workflow with the current Actions major versions used in this repo

## Testing
- not run locally
