### PR TITLE
Trim trailing empty line from README.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ format:
 format_doc:
 	# Trim white space
 	sed -i -e 's_[[:space:]]*$$__' README.md
+	# Trim trailing empty line
+	sed -i -e '$${/^$$/d;}' README.md
 	# Replace true->True false->False: sed -e "s/\b\(false\|true\)/\u\1/g"
 	find . -type f -iname '*.md' -exec sed -i -e 's_\b\(false\|true\)_\u\1_g' '{}' \;
 


### PR DESCRIPTION
## Summary
- Enhance `format_doc` target to trim trailing empty line from README.md

## Test plan
- [ ] Verify `make format_doc` runs successfully
- [ ] Verify README.md has no trailing empty line after generation