### PR TITLE
Fix insert-example adding extra trailing newline

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,4 +149,3 @@ Class | Method | HTTP request | Description
 - [RecognizeBase64Request](docs/RecognizeBase64Request.md)
 - [RegionPoint](docs/RegionPoint.md)
 - [ScanBase64Request](docs/ScanBase64Request.md)
-

--- a/scripts/insert-example.py
+++ b/scripts/insert-example.py
@@ -20,7 +20,7 @@ def main(template: typing.TextIO) -> None:
         return read_text(file_name)
 
     text = REPLACE_RE.sub(sub_match, content)
-    print(text)
+    print(text, end="")
 
 
 def parse_args() -> typing.Dict[str, typing.Any]:


### PR DESCRIPTION
## Summary
- Fix `insert-example.py` using `print(text, end="")` to avoid adding extra trailing newline
- Remove trailing empty line from README.md

## Test plan
- [ ] Run `make after-gen` and verify README.md has no trailing empty line